### PR TITLE
Remove account ID requirement and add diagnostics support for Anglian Water integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,6 @@ Ensure you have logged into the new Anglian Water mobile app at least once befor
 1. Restart Home Assistant.
 1. In the HA UI, go to "Configuration" -> "Integrations," click "+," and search for "Anglian Water."
 
-## Retrieving account ID
-
-As of 2nd April 2025, Anglian Water have turned off all of the old API endpoints this integration was using, therefore it not longer pulls back more than a couple of days worth of data. While the integration will handle auth successfully, you will need to provide your encrypted account ID. To get this, you can login to the standard Anglian Water website with dev tools open, monitoring the network calls to `https://apims-waf.awis.systems`.
-
-1. Launch browser of your choice, open Dev Tools (Inspect Element)
-1. Within Dev Tools window, switch to the network tab
-1. In the filter, enter `apims-waf.awis.systems`
-1. Login to Anglian Water's website as normal (https://myaccount.anglianwater.co.uk)
-1. Within Dev Tools, you will see a number of HTTP requests made, the first 2 should contain `state` in the `File` column. Select the request after with a bunch of random numbers and letters (first GET request)
-1. Your account ID is everything after `https://apims-waf.awis.systems/myaccount/v1/accounts/` in the URL on the right hand side, copy the entire string.
-1. Paste the copied string into the Account ID field in the config flow
-
 ## Configuration is done in the UI
 
 <!---->

--- a/custom_components/anglian_water/__init__.py
+++ b/custom_components/anglian_water/__init__.py
@@ -50,7 +50,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _api = MSOB2CAuth(
             username=entry.data[CONF_USERNAME],
             password=entry.data[CONF_PASSWORD],
-            account_id=entry.data[CONF_ACCOUNT_ID],
             refresh_token=entry.data.get(CONF_ACCESS_TOKEN, None),
             session=async_get_clientsession(hass),
         )
@@ -114,6 +113,14 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         new_data.update(entry.options)
     if entry.version > CONF_VERSION:
         _LOGGER.debug("Migration not needed")
+        return True
+    if entry.version == 3:
+        _LOGGER.debug(
+            "Dropping account ID from config as this is no longer required")
+        new_data.pop(CONF_ACCOUNT_ID, None)
+        hass.config_entries.async_update_entry(
+            entry, data=new_data, version=CONF_VERSION
+        )
         return True
     if entry.version < 3:
         if CONF_ACCOUNT_ID in entry.data:

--- a/custom_components/anglian_water/config_flow.py
+++ b/custom_components/anglian_water/config_flow.py
@@ -19,7 +19,6 @@ from pyanglianwater.exceptions import (
 from .const import (
     DOMAIN,
     LOGGER,
-    CONF_ACCOUNT_ID,
     CONF_TARIFF,
     CONF_CUSTOM_RATE,
     CONF_VERSION,

--- a/custom_components/anglian_water/config_flow.py
+++ b/custom_components/anglian_water/config_flow.py
@@ -74,10 +74,6 @@ class AnglianWaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_ACCOUNT_ID,
-                        default=(user_input or {}).get(CONF_ACCOUNT_ID, ""),
-                    ): selector.TextSelector(),
-                    vol.Required(
                         CONF_USERNAME,
                         default=(user_input or {}).get(CONF_USERNAME, ""),
                     ): selector.TextSelector(

--- a/custom_components/anglian_water/const.py
+++ b/custom_components/anglian_water/const.py
@@ -13,5 +13,5 @@ VERSION = _version.__version__
 CONF_ACCOUNT_ID = "account_id"
 CONF_TARIFF = "tariff"
 CONF_CUSTOM_RATE = "custom_rate"
-CONF_VERSION = 3
+CONF_VERSION = 4
 CONF_AREA = "area"

--- a/custom_components/anglian_water/diagnostics.py
+++ b/custom_components/anglian_water/diagnostics.py
@@ -5,6 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from typing import Any
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from pyanglianwater.enum import UsagesReadGranularity
@@ -22,7 +23,7 @@ REDACTED_FIELDS = [
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Get diagnostics for a config entry."""
     entry = hass.data[DOMAIN][config_entry.entry_id]
     return {

--- a/custom_components/anglian_water/diagnostics.py
+++ b/custom_components/anglian_water/diagnostics.py
@@ -1,16 +1,15 @@
-"""Home Assistant Anglian Water Diagnostics"""
+"""Home Assistant Anglian Water Diagnostics."""
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from typing import Any
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from pyanglianwater.enum import UsagesReadGranularity
 
-from .const import DOMAIN, VERSION
+from .const import DOMAIN
 
 REDACTED_FIELDS = [
     CONF_USERNAME,

--- a/custom_components/anglian_water/diagnostics.py
+++ b/custom_components/anglian_water/diagnostics.py
@@ -44,7 +44,7 @@ async def async_get_device_diagnostics(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     device_entry: DeviceEntry,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Get diagnostics for a device entry."""
     entry = hass.data[DOMAIN][config_entry.entry_id]
     meter = entry.client.meters.get(device_entry.serial_number, None)

--- a/custom_components/anglian_water/diagnostics.py
+++ b/custom_components/anglian_water/diagnostics.py
@@ -1,0 +1,58 @@
+"""Home Assistant Anglian Water Diagnostics"""
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_ACCESS_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from pyanglianwater.enum import UsagesReadGranularity
+
+from .const import DOMAIN, VERSION
+
+REDACTED_FIELDS = [
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    CONF_ACCESS_TOKEN,
+    "refresh_token",
+]
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> dict[str, str]:
+    """Get diagnostics for a config entry."""
+    entry = hass.data[DOMAIN][config_entry.entry_id]
+    return {
+        "config_entry": async_redact_data(config_entry.data, REDACTED_FIELDS),
+        "options": async_redact_data(config_entry.options, REDACTED_FIELDS),
+        "anglian_water": async_redact_data(entry.client.to_dict(), REDACTED_FIELDS),
+        "metering_data": async_redact_data(
+            await entry.client.get_usages(
+                interval=UsagesReadGranularity.HOURLY,
+                update_cache=False
+            ),
+            REDACTED_FIELDS
+        )
+    }
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    device_entry: DeviceEntry,
+) -> dict[str, str]:
+    """Get diagnostics for a device entry."""
+    entry = hass.data[DOMAIN][config_entry.entry_id]
+    meter = entry.client.meters.get(device_entry.serial_number, None)
+    if meter is not None:
+        meter = meter.to_dict()
+    return {
+        "device_entry": async_redact_data(device_entry.serial_number, REDACTED_FIELDS),
+        "config_entry": async_redact_data(device_entry.config_entries, REDACTED_FIELDS),
+        "device_id": device_entry.id,
+        "serial": device_entry.serial_number,
+        "meter": async_redact_data(meter, REDACTED_FIELDS),
+    }

--- a/custom_components/anglian_water/diagnostics.py
+++ b/custom_components/anglian_water/diagnostics.py
@@ -49,6 +49,8 @@ async def async_get_device_diagnostics(
     meter = entry.client.meters.get(device_entry.serial_number, None)
     if meter is not None:
         meter = meter.to_dict()
+    else:
+        meter = {}
     return {
         "device_entry": async_redact_data(device_entry.serial_number, REDACTED_FIELDS),
         "config_entry": async_redact_data(device_entry.config_entries, REDACTED_FIELDS),

--- a/custom_components/anglian_water/manifest.json
+++ b/custom_components/anglian_water/manifest.json
@@ -16,7 +16,7 @@
     "anglian_water"
   ],
   "requirements": [
-    "pyanglianwater==2025.4.6"
+    "pyanglianwater==2025.4.7"
   ],
   "version": "0.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.9.0
 homeassistant==2025.4.0
 pip>=24.1.1,<25.1
 ruff==0.11.4
-pyanglianwater==2025.4.6
+pyanglianwater==2025.4.7


### PR DESCRIPTION
Eliminate the need for an account ID in the configuration, update the integration version, and introduce diagnostics capabilities to enhance troubleshooting for users. Handle cases of missing meter data by initializing it to an empty dictionary.