### PR TITLE
Update pyanglianwater and improve configuration flow

### DIFF
--- a/custom_components/anglian_water/__init__.py
+++ b/custom_components/anglian_water/__init__.py
@@ -138,9 +138,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug("Migration not needed")
         return True
     if entry.version == 3:
-        _LOGGER.debug(
-            "Dropping account ID from config as this is no longer required")
-        new_data.pop(CONF_ACCOUNT_ID, None)
         hass.config_entries.async_update_entry(
             entry, data=new_data, version=CONF_VERSION
         )

--- a/custom_components/anglian_water/config_flow.py
+++ b/custom_components/anglian_water/config_flow.py
@@ -21,7 +21,8 @@ from .const import (
     CONF_CUSTOM_RATE,
     CONF_VERSION,
     CONF_AREA,
-    ANGLIAN_WATER_AREAS
+    ANGLIAN_WATER_AREAS,
+    CONF_ACCOUNT_ID
 )
 
 
@@ -78,6 +79,14 @@ class AnglianWaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         selector.TextSelectorConfig(
                             type=selector.TextSelectorType.PASSWORD
                         ),
+                    ),
+                    vol.Optional(
+                        CONF_ACCOUNT_ID,
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            mode=selector.NumberSelectorMode.BOX,
+                            step=1
+                        )
                     ),
                     vol.Required(
                         CONF_AREA,

--- a/custom_components/anglian_water/manifest.json
+++ b/custom_components/anglian_water/manifest.json
@@ -16,7 +16,7 @@
     "anglian_water"
   ],
   "requirements": [
-    "pyanglianwater==2025.4.12"
+    "pyanglianwater==2025.4.13"
   ],
   "version": "0.0.0"
 }

--- a/custom_components/anglian_water/translations/en.json
+++ b/custom_components/anglian_water/translations/en.json
@@ -2,12 +2,12 @@
     "config": {
         "step": {
             "user": {
-                "description": "If you need help with the configuration have a look here: https://github.com/pantherale0/haanglianwater",
+                "description": "If you need help with the configuration have a look here: https://github.com/pantherale0/haanglianwater\n\nYour account number is usually collected automatically, however some accounts require this to be manually set.\n\nYour account number is found either on the Anglian Water website or within your latest bill.",
                 "data": {
                     "username": "Email",
                     "password": "Password",
                     "device_id": "Device ID",
-                    "account_id": "Account ID",
+                    "account_id": "Account Number",
                     "area": "Area"
                 }
             },

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.9.0
 homeassistant==2025.4.0
 pip>=24.1.1,<25.1
 ruff==0.11.5
-pyanglianwater==2025.4.12
+pyanglianwater==2025.4.13


### PR DESCRIPTION
Bump the pyanglianwater library to version 2025.4.13. Remove the unnecessary account ID from the migration process and reintroduce it in the configuration flow. Update the configuration description and rename account ID to account number in translations.