### PR TITLE
Change account ID input to text selector in configuration flow

### DIFF
--- a/custom_components/anglian_water/config_flow.py
+++ b/custom_components/anglian_water/config_flow.py
@@ -82,12 +82,7 @@ class AnglianWaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     ),
                     vol.Optional(
                         CONF_ACCOUNT_ID,
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            mode=selector.NumberSelectorMode.BOX,
-                            step=1
-                        )
-                    ),
+                    ): selector.TextSelector(),
                     vol.Required(
                         CONF_AREA,
                     ): selector.SelectSelector(


### PR DESCRIPTION
Replace the account ID input method from a number selector to a text selector for improved flexibility in the configuration flow.