### PR TITLE
Update pyanglianwater to version 2025.6.0 and handle SmartMeterUnavailableError

### DIFF
--- a/custom_components/anglian_water/__init__.py
+++ b/custom_components/anglian_water/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.core import (
     ServiceResponse,
     SupportsResponse,
 )
-from homeassistant.exceptions import ConfigEntryNotReady, ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import issue_registry as ir
 from pyanglianwater import AnglianWater
@@ -100,25 +100,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             is_fixable=False,
             is_persistent=False,
             severity=ir.IssueSeverity.WARNING,
-            translation_domain=DOMAIN,
             translation_key="maintenance",
         )
         raise ConfigEntryNotReady(
             exception, translation_domain=DOMAIN, translation_key="maintenance"
         ) from exception
-    except SmartMeterUnavailableError as exception:
+    except SmartMeterUnavailableError:
         ir.async_create_issue(
             hass,
             DOMAIN,
             "smart_meter_unavailable",
             is_fixable=False,
-            is_persistent=False,
-            severity=ir.IssueSeverity.WARNING,
-            translation_domain=DOMAIN,
+            is_persistent=True,
+            severity=ir.IssueSeverity.ERROR,
             translation_key="smart_meter_unavailable",
         )
-        raise ConfigEntryAuthFailed(exception, translation_domain=DOMAIN,
-                                    translation_key="smart_meter_unavailable") from exception
+        return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/anglian_water/coordinator.py
+++ b/custom_components/anglian_water/coordinator.py
@@ -15,7 +15,8 @@ from pyanglianwater.exceptions import (
     UnknownEndpointError,
     ExpiredAccessTokenError,
     ServiceUnavailableError,
-    InvalidAccountIdError
+    InvalidAccountIdError,
+    SmartMeterUnavailableError
 )
 
 from .const import DOMAIN, LOGGER
@@ -54,3 +55,5 @@ class AnglianWaterDataUpdateCoordinator(DataUpdateCoordinator):
             # No need to retry here, because module already refreshes the token
             # This error is something different
             raise UpdateFailed(exception) from exception
+        except SmartMeterUnavailableError:
+            return  # ignore this error

--- a/custom_components/anglian_water/manifest.json
+++ b/custom_components/anglian_water/manifest.json
@@ -16,7 +16,7 @@
     "anglian_water"
   ],
   "requirements": [
-    "pyanglianwater==2025.4.14"
+    "pyanglianwater==2025.6.0"
   ],
   "version": "0.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.9.0
 homeassistant==2025.4.0
 pip>=24.1.1,<25.2
 ruff==0.11.13
-pyanglianwater==2025.4.14
+pyanglianwater==2025.6.0


### PR DESCRIPTION
Upgrade the pyanglianwater dependency and improve error handling for SmartMeterUnavailableError to ensure better integration stability.