### PR TITLE
Add state_class to angian_water_previous_cost sensor entity

### DIFF
--- a/custom_components/anglian_water/sensor.py
+++ b/custom_components/anglian_water/sensor.py
@@ -50,6 +50,7 @@ ENTITY_DESCRIPTIONS: dict[str, AnglianWaterSensorEntityDescription] = {
         native_unit_of_measurement="GBP",
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda entity: entity.get_yesterday_cost,
+        state_class=SensorStateClass.TOTAL_INCREASING
     ),
     "anglian_water_latest_reading": AnglianWaterSensorEntityDescription(
         key="anglian_water_latest_reading",

--- a/custom_components/anglian_water/sensor.py
+++ b/custom_components/anglian_water/sensor.py
@@ -41,7 +41,7 @@ ENTITY_DESCRIPTIONS: dict[str, AnglianWaterSensorEntityDescription] = {
         native_unit_of_measurement=UnitOfVolume.LITERS,
         device_class=SensorDeviceClass.WATER,
         value_fn=lambda entity: entity.get_yesterday_consumption,
-        state_class=SensorStateClass.TOTAL_INCREASING
+        state_class=SensorStateClass.TOTAL
     ),
     "anglian_water_previous_cost": AnglianWaterSensorEntityDescription(
         key="anglian_water_previous_cost",
@@ -50,7 +50,7 @@ ENTITY_DESCRIPTIONS: dict[str, AnglianWaterSensorEntityDescription] = {
         native_unit_of_measurement="GBP",
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda entity: entity.get_yesterday_cost,
-        state_class=SensorStateClass.TOTAL_INCREASING
+        state_class=SensorStateClass.TOTAL
     ),
     "anglian_water_latest_reading": AnglianWaterSensorEntityDescription(
         key="anglian_water_latest_reading",


### PR DESCRIPTION
Introduce the `state_class` attribute to the `anglian_water_previous_cost` sensor entity to indicate that its value is a total that only increases.

Fixes #125