### PR TITLE
Fix cookie handling in authentication for cookie jar

### DIFF
--- a/custom_components/anglian_water/__init__.py
+++ b/custom_components/anglian_water/__init__.py
@@ -53,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             refresh_token=entry.data.get(CONF_ACCESS_TOKEN, None),
             session=async_create_clientsession(
                 hass,
-                jar=CookieJar(quote_cookie=False)),
+                cookie_jar=CookieJar(quote_cookie=False)),
             account_number=entry.data.get(CONF_ACCOUNT_ID, None),
         )
         await _api.send_login_request()

--- a/custom_components/anglian_water/__init__.py
+++ b/custom_components/anglian_water/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 
+from aiohttp import CookieJar
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import (
@@ -16,7 +17,7 @@ from homeassistant.core import (
     SupportsResponse,
 )
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers import issue_registry as ir
 from pyanglianwater import AnglianWater
 from pyanglianwater.auth import MSOB2CAuth
@@ -50,7 +51,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             username=entry.data[CONF_USERNAME],
             password=entry.data[CONF_PASSWORD],
             refresh_token=entry.data.get(CONF_ACCESS_TOKEN, None),
-            session=async_get_clientsession(hass),
+            session=async_create_clientsession(
+                hass,
+                jar=CookieJar(quote_cookie=False)),
             account_number=entry.data.get(CONF_ACCOUNT_ID, None),
         )
         await _api.send_login_request()

--- a/custom_components/anglian_water/config_flow.py
+++ b/custom_components/anglian_water/config_flow.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import voluptuous as vol
+from aiohttp import CookieJar
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONF_ACCESS_TOKEN
 from homeassistant.helpers import selector
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from pyanglianwater.auth import MSOB2CAuth
 from pyanglianwater.exceptions import (
     ServiceUnavailableError,
@@ -43,7 +44,10 @@ class AnglianWaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 auth = MSOB2CAuth(
                     username=user_input[CONF_USERNAME],
                     password=user_input[CONF_PASSWORD],
-                    session=async_get_clientsession(self.hass),
+                    session=async_create_clientsession(
+                        self.hass,
+                        cookie_jar=CookieJar(quote_cookie=False)
+                    ),
                 )
                 await auth.send_login_request()
                 user_input[CONF_ACCESS_TOKEN] = auth.refresh_token

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Anglian Water",
     "filename": "anglian_water.zip",
     "hide_default_branch": true,
-    "homeassistant": "2023.8.0",
+    "homeassistant": "2025.6.0",
     "render_readme": true,
     "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.9.0
-homeassistant==2025.4.0
+homeassistant==2025.6.0
 pip>=24.1.1,<25.2
 ruff==0.11.13
 pyanglianwater==2025.6.0


### PR DESCRIPTION
The quoted cookie handling implemented in aiohttp 3.12.7 breaks the login, which has been pushed into HA core preventing the integration from working.

This change fixes that, however now the minimum HA version is 2025.6.0...

Related: https://github.com/aio-libs/aiohttp/issues/11200